### PR TITLE
Updated web.xml for test applications in jsf buckets to use HmacSHA256 algorithm

### DIFF
--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/BeanValidationTests.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/BeanValidationTests.war/resources/WEB-INF/web.xml
@@ -22,6 +22,16 @@
         <param-value>server</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDIConfigByACP.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDIConfigByACP.war/resources/WEB-INF/web.xml
@@ -24,6 +24,16 @@
     <param-name>javax.faces.PROJECT_STAGE</param-name>
     <param-value>Development</param-value>
   </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+    <param-value>HmacSHA256</param-value>
+  </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.ALGORITHM</param-name>
+    <param-value>AES</param-value>
+  </context-param>
  
   <servlet>
     <servlet-name>Faces Servlet</servlet-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDIFacesFlows.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDIFacesFlows.war/resources/WEB-INF/web.xml
@@ -37,4 +37,14 @@
     <url-pattern>*.xhtml</url-pattern>
   </servlet-mapping>
 
+  	<context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDIFacesInMetaInf.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDIFacesInMetaInf.war/resources/WEB-INF/web.xml
@@ -24,6 +24,16 @@
     <param-name>javax.faces.PROJECT_STAGE</param-name>
     <param-value>Development</param-value>
   </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+    <param-value>HmacSHA256</param-value>
+  </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.ALGORITHM</param-name>
+    <param-value>AES</param-value>
+  </context-param>
  
   <servlet>
     <servlet-name>Faces Servlet</servlet-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDIFacesInWebXML.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDIFacesInWebXML.war/resources/WEB-INF/web.xml
@@ -32,6 +32,16 @@
     <param-name>javax.faces.PROJECT_STAGE</param-name>
     <param-value>Development</param-value>
   </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+    <param-value>HmacSHA256</param-value>
+  </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.ALGORITHM</param-name>
+    <param-value>AES</param-value>
+  </context-param>
  
   <servlet>
     <servlet-name>Faces Servlet</servlet-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDITests.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDITests.war/resources/WEB-INF/web.xml
@@ -24,6 +24,16 @@
     <param-name>javax.faces.PROJECT_STAGE</param-name>
     <param-value>Development</param-value>
   </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+    <param-value>HmacSHA256</param-value>
+  </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.ALGORITHM</param-name>
+    <param-value>AES</param-value>
+  </context-param>
  
   <servlet>
     <servlet-name>Faces Servlet</servlet-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/JSF22FacesFlows.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/JSF22FacesFlows.war/resources/WEB-INF/web.xml
@@ -37,4 +37,14 @@
         <url-pattern>*.xhtml</url-pattern>
     </servlet-mapping>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PH06008.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PH06008.war/resources/WEB-INF/web.xml
@@ -31,4 +31,15 @@
         <servlet-name>Faces Servlet</servlet-name>
         <url-pattern>*.xhtml</url-pattern>
     </servlet-mapping>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+    
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI46218Flow1.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI46218Flow1.war/resources/WEB-INF/web.xml
@@ -30,4 +30,15 @@
         <servlet-name>Faces Servlet</servlet-name>
         <url-pattern>*.xhtml</url-pattern>
     </servlet-mapping>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI46218Flow2.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI46218Flow2.war/resources/WEB-INF/web.xml
@@ -30,4 +30,14 @@
         <servlet-name>Faces Servlet</servlet-name>
         <url-pattern>*.xhtml</url-pattern>
     </servlet-mapping>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI47600.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI47600.war/resources/WEB-INF/web.xml
@@ -31,5 +31,15 @@
 	<welcome-file-list>
 		<welcome-file>/faces/index.xhtml</welcome-file>
 	</welcome-file-list>
+
+	<context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
 	
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI50108.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI50108.war/resources/WEB-INF/web.xml
@@ -23,6 +23,16 @@
         <param-value>false</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI51038.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI51038.war/resources/WEB-INF/web.xml
@@ -24,6 +24,16 @@
     </context-param>
 
     <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
+    <context-param>
         <param-name>org.apache.myfaces.SUPPORT_EL_3_IMPORT_HANDLER</param-name>
         <param-value>true</param-value>
     </context-param>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI51038_Default.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI51038_Default.war/resources/WEB-INF/web.xml
@@ -23,6 +23,16 @@
         <param-value>false</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI57255CDI.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI57255CDI.war/resources/WEB-INF/web.xml
@@ -30,4 +30,15 @@
         <servlet-name>Faces Servlet</servlet-name>
         <url-pattern>*.xhtml</url-pattern>
     </servlet-mapping>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+    
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI57255Default.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI57255Default.war/resources/WEB-INF/web.xml
@@ -30,4 +30,14 @@
         <servlet-name>Faces Servlet</servlet-name>
         <url-pattern>*.xhtml</url-pattern>
     </servlet-mapping>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI59422.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI59422.war/resources/WEB-INF/web.xml
@@ -30,4 +30,14 @@
         <servlet-name>Faces Servlet</servlet-name>
         <url-pattern>*.xhtml</url-pattern>
     </servlet-mapping>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI63135.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI63135.war/resources/WEB-INF/web.xml
@@ -32,4 +32,14 @@
         <param-name>javax.faces.INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL</param-name>
         <param-value>true</param-value>
     </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI64714.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI64714.war/resources/WEB-INF/web.xml
@@ -46,4 +46,15 @@
         <param-name>javax.faces.VALIDATE_EMPTY_FIELDS</param-name>
         <param-value>true</param-value>
     </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI64718.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI64718.war/resources/WEB-INF/web.xml
@@ -42,4 +42,14 @@
         <param-value>true</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI67525.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI67525.war/resources/WEB-INF/web.xml
@@ -33,4 +33,14 @@
         <param-value>1</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI89168.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI89168.war/resources/WEB-INF/web.xml
@@ -22,4 +22,14 @@
         <servlet-name>Faces Servlet</servlet-name>
         <url-pattern>*.xhtml</url-pattern>
     </servlet-mapping>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI90391.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI90391.war/resources/WEB-INF/web.xml
@@ -23,6 +23,16 @@
         <param-value>Development</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	    <param-value>HmacSHA256</param-value>
+    </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI90507.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI90507.war/resources/WEB-INF/web.xml
@@ -39,4 +39,14 @@
         <param-name>com.ibm.ws.jsf.DisableFaceletActionListenerPreDestroy</param-name>
         <param-value>true</param-value>
     </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/ViewScopedCDIBean.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/ViewScopedCDIBean.war/resources/WEB-INF/web.xml
@@ -34,4 +34,14 @@
         <welcome-file>index.jsf</welcome-file>
     </welcome-file-list>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/ViewScopedJSFBean.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/ViewScopedJSFBean.war/resources/WEB-INF/web.xml
@@ -34,4 +34,14 @@
         <welcome-file>index.jsf</welcome-file>
     </welcome-file-list>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ActionListener.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ActionListener.war/resources/WEB-INF/web.xml
@@ -22,6 +22,17 @@
     <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
     <param-value>server</param-value>
   </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	<param-value>HmacSHA256</param-value>
+  </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
+  
   <servlet>
     <servlet-name>Faces Servlet</servlet-name>
     <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22AppConfigPop.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22AppConfigPop.war/resources/WEB-INF/web.xml
@@ -23,6 +23,16 @@
         <param-value>server</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	    <param-value>HmacSHA256</param-value>
+    </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22BackwardCompatibilityTests.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22BackwardCompatibilityTests.war/resources/WEB-INF/web.xml
@@ -23,6 +23,16 @@
         <param-value>server</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	    <param-value>HmacSHA256</param-value>
+    </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ClientWindow.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ClientWindow.war/resources/WEB-INF/web.xml
@@ -28,6 +28,16 @@
         <param-value>server</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	    <param-value>HmacSHA256</param-value>
+    </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ClientWindowFaces40.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ClientWindowFaces40.war/resources/WEB-INF/web.xml
@@ -28,6 +28,16 @@
         <param-value>server</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	    <param-value>HmacSHA256</param-value>
+    </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ComponentRenderer.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ComponentRenderer.war/resources/WEB-INF/web.xml
@@ -37,4 +37,12 @@
         <param-name>javax.faces.PROJECT_STAGE</param-name>
         <param-value>Development</param-value>
     </context-param>
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ComponentTester.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ComponentTester.war/resources/WEB-INF/web.xml
@@ -39,6 +39,16 @@
         <param-value>Development</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
     <!-- Increase buffer size so the response is not committed. -->
     <context-param>
         <param-name>jakarta.faces.FACELETS_BUFFER_SIZE</param-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22FaceletsResourceResolverAnnotation.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22FaceletsResourceResolverAnnotation.war/resources/WEB-INF/web.xml
@@ -34,5 +34,15 @@
 	<welcome-file-list>
     	<welcome-file>index.xhtml</welcome-file>
   	</welcome-file-list>
+
+	<context-param>
+    	<param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+    	<param-value>HmacSHA256</param-value>
+  	</context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
 	 
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22FlashEvents.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22FlashEvents.war/resources/WEB-INF/web.xml
@@ -22,6 +22,16 @@
     <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
     <param-value>server</param-value>
   </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	<param-value>HmacSHA256</param-value>
+  </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
  
   <servlet>
     <servlet-name>Faces Servlet</servlet-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22HTML5.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22HTML5.war/resources/WEB-INF/web.xml
@@ -21,6 +21,17 @@
         <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
         <param-value>server</param-value>
     </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	    <param-value>HmacSHA256</param-value>
+    </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22InputFile.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22InputFile.war/resources/WEB-INF/web.xml
@@ -37,6 +37,16 @@
         <welcome-file>fileUploadTest.jsf</welcome-file>
     </welcome-file-list>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
     <!-- Required for testAjaxInputFile to ensure any errors are alerted  -->
     <context-param>
         <param-name>javax.faces.PROJECT_STAGE</param-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22LocalizationTester.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22LocalizationTester.war/resources/WEB-INF/web.xml
@@ -41,6 +41,16 @@
         <param-value>false</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
     <!-- Temp solution for defect 294367; need to look into o.a.m.ALWAYS_FORCE_SESSION_CREATION for 4.0 -->
     <context-param>
         <param-name>jakarta.faces.FACELETS_BUFFER_SIZE</param-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22SimpleHTML.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22SimpleHTML.war/resources/WEB-INF/web.xml
@@ -18,15 +18,26 @@
     
   <display-name>JSF22SimpleHTML</display-name>
 
-    <context-param>
-        <param-name>javax.faces.PROJECT_STAGE</param-name>
-        <param-value>Development</param-value>
-    </context-param>
+  <context-param>
+    <param-name>javax.faces.PROJECT_STAGE</param-name>
+    <param-value>Development</param-value>
+  </context-param>
   
   <context-param>
     <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
     <param-value>server</param-value>
   </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+    <param-value>HmacSHA256</param-value>
+  </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.ALGORITHM</param-name>
+    <param-value>AES</param-value>
+  </context-param>
+
   <servlet>
     <servlet-name>Faces Servlet</servlet-name>
     <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22TestResources.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22TestResources.war/resources/WEB-INF/web.xml
@@ -30,6 +30,16 @@
         <param-value>WEB-INF/resources</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	    <param-value>HmacSHA256</param-value>
+    </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ViewPooling.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ViewPooling.war/resources/WEB-INF/web.xml
@@ -22,6 +22,16 @@
     <param-name>javax.faces.PROJECT_STAGE</param-name>
     <param-value>Production</param-value>
   </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	<param-value>HmacSHA256</param-value>
+  </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
  
   <servlet>
     <servlet-name>Faces Servlet</servlet-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestJSF2.2.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestJSF2.2.war/resources/WEB-INF/web.xml
@@ -22,6 +22,17 @@
     <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
     <param-value>server</param-value>
   </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+    <param-value>HmacSHA256</param-value>
+  </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.ALGORITHM</param-name>
+    <param-value>AES</param-value>
+  </context-param>
+
   <servlet>
     <servlet-name>Faces Servlet</servlet-name>
     <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestJSF22ViewAction.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestJSF22ViewAction.war/resources/WEB-INF/web.xml
@@ -32,5 +32,15 @@
     <servlet-name>Faces Servlet</servlet-name>
     <url-pattern>*.jsf</url-pattern>
   </servlet-mapping>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	<param-value>HmacSHA256</param-value>
+  </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
   
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestJSFEL.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestJSFEL.war/resources/WEB-INF/web.xml
@@ -29,7 +29,16 @@
 	     <param-name>javax.faces.FACELETS_LIBRARIES</param-name>
          <param-value>/WEB-INF/custom-taglib.xml</param-value>
     </context-param>
-	
+
+	<context-param>
+    	<param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  		<param-value>HmacSHA256</param-value>
+  	</context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
 
 	<!-- Faces Servlet -->
 	<servlet>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestResourceContracts.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestResourceContracts.war/resources/WEB-INF/web.xml
@@ -24,6 +24,14 @@
         <param-name>org.apache.myfaces.LOG_WEB_CONTEXT_PARAMS</param-name>
         <param-value>false</param-value>
     </context-param>
+    	<context-param>
+    	<param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  		<param-value>HmacSHA256</param-value>
+  	</context-param>
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
 
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestResourceContractsDirectory.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestResourceContractsDirectory.war/resources/WEB-INF/web.xml
@@ -28,6 +28,14 @@
         <param-name>javax.faces.WEBAPP_CONTRACTS_DIRECTORY</param-name>
         <param-value>myContracts</param-value>
     </context-param>
+    	<context-param>
+    	<param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  		<param-value>HmacSHA256</param-value>
+  	</context-param>
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestResourceContractsFromJar.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestResourceContractsFromJar.war/resources/WEB-INF/web.xml
@@ -24,7 +24,14 @@
         <param-name>org.apache.myfaces.LOG_WEB_CONTEXT_PARAMS</param-name>
         <param-value>false</param-value>
     </context-param>
-
+    	<context-param>
+    	<param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  		<param-value>HmacSHA256</param-value>
+  	</context-param>
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>


### PR DESCRIPTION
Updated the web.xml of test applications in jsf.2.2_fat and jsf.2.2_fat.2 to override the default HmacSHA1 to HmacSHA256. Also need to override the DES default algorithm to AES.